### PR TITLE
add parameters of filtering for vietnamese

### DIFF
--- a/ac_dc/parameters_filtering.py
+++ b/ac_dc/parameters_filtering.py
@@ -30,7 +30,13 @@ parameters_filtering_en = parameters_filtering_default
 parameters_filtering_en["cond_remove_long_words"] = True
 parameters_filtering_en["length_word_cutoff"] = 25
 
+parameters_filtering_vi = parameters_filtering_default
+parameters_filtering_vi["cond_remove_long_words"] = True
+parameters_filtering_vi["length_word_cutoff"] = 20
+parameters_filtering_vi["special_characters_cutoff"] = 0.35
+
 parameters_filtering = {
     "default": parameters_filtering_default,
     "en": parameters_filtering_en,
+    "vi": parameters_filtering_vi,
 }


### PR DESCRIPTION
Added some specific parameters of filtering for Vietnamese language like ignoring words with a length of more than 20 since most of them are urls, meaningless words, and do not exist in VN vocab.