### PR TITLE
Add argument to load the Oscar dataset with registry info

### DIFF
--- a/ac_dc/main_filtering.py
+++ b/ac_dc/main_filtering.py
@@ -37,6 +37,18 @@ def parseArgs():
         default="../Oscar_filtered/",
         help="Path to the directory where the filtered version of Oscar will be saved.",
     )
+    parser.add_argument(
+        "--use_registry",
+        type=bool,
+        default=False,
+        help="Whether to use the Oscar dataset containing registry information.",
+    )
+    parser.add_argument(
+        "--registry_data_files",
+        type=str,
+        default=None,
+        help="Data files from the Hugging Face hub to load.",
+    )
     args = parser.parse_args()
     return args
 
@@ -49,6 +61,8 @@ def main():
         path_kenlm_model=args.path_kenlm_model,
         num_proc=args.num_proc,
         path_dir_save_oscar=args.path_dir_save_oscar,
+        use_registry=args.use_registry,
+        registry_data_files=args.registry_data_files,
     )
     oscar_filtering.modifying_sentences()
     oscar_filtering.filtering()

--- a/ac_dc/oscar_sample_filter.py
+++ b/ac_dc/oscar_sample_filter.py
@@ -403,13 +403,21 @@ class OscarFiltering:
         path_kenlm_model,
         num_proc,
         path_dir_save_oscar,
+        use_registry,
+        registry_data_files,
     ):
         self.lang_oscar_id = lang_oscar_id
         self.path_fasttext_model = path_fasttext_model
         self.path_kenlm_model = path_kenlm_model
-        self.ds = load_dataset(
-            "oscar", f"unshuffled_deduplicated_{self.lang_oscar_id}"
-        )["train"]
+        if use_registry:
+            data_files = registry_data_files if registry_data_files else f"{lang_oscar_id}/*.jsonl.gz"
+            self.ds = load_dataset(
+                "mhtoin/register_oscar", data_files=data_files,
+            )["train"]
+        else:
+            self.ds = load_dataset(
+                "oscar", f"unshuffled_deduplicated_{self.lang_oscar_id}"
+            )["train"]
         self.num_proc = num_proc
         self.path_dir_save_oscar = path_dir_save_oscar
 

--- a/ac_dc/oscar_sample_filter.py
+++ b/ac_dc/oscar_sample_filter.py
@@ -410,9 +410,14 @@ class OscarFiltering:
         self.path_fasttext_model = path_fasttext_model
         self.path_kenlm_model = path_kenlm_model
         if use_registry:
-            data_files = registry_data_files if registry_data_files else f"{lang_oscar_id}/*.jsonl.gz"
+            data_files = (
+                registry_data_files
+                if registry_data_files
+                else f"{lang_oscar_id}/*.jsonl.gz"
+            )
             self.ds = load_dataset(
-                "mhtoin/register_oscar", data_files=data_files,
+                "mhtoin/register_oscar",
+                data_files=data_files,
             )["train"]
         else:
             self.ds = load_dataset(


### PR DESCRIPTION
I add some arguments to support loading the Oscar dataset containing the registry information (https://huggingface.co/datasets/mhtoin/register_oscar). We can then leverage these labels for further filtering in the pipeline. 

One nice thing about using `mhtoin/register_oscar` is that we can load specific files (or regex/wildcards) instead of downloading the entire dataset for a language. 

Usage:

```bash
python main_filtering.py --use_registry True --registry_data_files "en/en_00000.jsonl.gz"
``` 