### PR TITLE
Add GH Action to self-assign issues

### DIFF
--- a/.github/workflows/self-assign.yaml
+++ b/.github/workflows/self-assign.yaml
@@ -1,0 +1,15 @@
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+      && !github.event.issue.assignee
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees


### PR DESCRIPTION
Add GH Action to self-assign issues.

This will allow self-assign issues to people without write access to the repo.

On the specific Issue page, they should make a comment containing only the keyword:
```
#self-assign
```