### PR TITLE
Add GitHub Action to label with help wanted

### DIFF
--- a/.github/workflows/label-with-help-wanted.yml
+++ b/.github/workflows/label-with-help-wanted.yml
@@ -1,0 +1,15 @@
+name: Label with help wanted
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#help' ||
+       github.event.comment.body == '#help-wanted')
+      && !github.event.issue.assignee
+    steps:
+      - run: |
+          echo "Labeling issue ${{ github.event.issue.number }} with 'help wanted'"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels

--- a/ac_dc/visualization/visualization.py
+++ b/ac_dc/visualization/visualization.py
@@ -117,7 +117,9 @@ def visualization(path_data, lang, num_docs, num_docs_for_words):
     ax.legend(["All data", "Data that we keep", "Data that is thrown away"])
     st.pyplot(fig)
 
-    st.markdown("If less than three curves are displayed, it means that there are overlaps.")
+    st.markdown(
+        "If less than three curves are displayed, it means that there are overlaps."
+    )
 
     st.header("Parameter of the filtering for words")
     max_len_word = int(np.max(words_data["len_word"])) + 1


### PR DESCRIPTION
Add GitHub Action to label with "help wanted".

This will allow to ask for for help to people without write access to the repo.

On the specific Issue page, they should make a comment containing only the keyword:
```
#help
```