### PR TITLE
Fix GitHub Action to label with help wanted

### DIFF
--- a/.github/workflows/label-with-help-wanted.yml
+++ b/.github/workflows/label-with-help-wanted.yml
@@ -8,7 +8,6 @@ jobs:
     if: >-
       (github.event.comment.body == '#help' ||
        github.event.comment.body == '#help-wanted')
-      && !github.event.issue.assignee
     steps:
       - run: |
           echo "Labeling issue ${{ github.event.issue.number }} with 'help wanted'"


### PR DESCRIPTION
Fix GitHub Action to label with help wanted.

Related to #268.